### PR TITLE
geocoder: add search control

### DIFF
--- a/places.html
+++ b/places.html
@@ -7,6 +7,10 @@
         <script src="https://unpkg.com/maplibre-gl@3.2.1/dist/maplibre-gl.js" crossorigin="anonymous"></script>
         <script src="https://unpkg.com/pmtiles@2.10.0-beta.0/dist/index.js"></script>
         <script src="https://unpkg.com/protomaps-themes-base@1.3.1/dist/index.js"></script>
+        <script
+            type="module"
+            src="https://s3.amazonaws.com/geocodeearth-missinglink/autocomplete-element/overture/bundle.js">
+        </script>
         <style>
             body {
                 margin: 0;
@@ -14,11 +18,29 @@
             #map {
                 height:100%; width:100%;
             }
+            #scroller {
+                z-index:999999;
+                position:absolute; top:0px ;right:0px;
+                color:white; padding:16px; background-color:#666;
+
+                @media only screen and (max-width: 600px) {
+                    margin-top: 60px;
+                }
+            }
+            #geocoder {
+                z-index: 999999;
+                position: fixed; top: 5px; left: 5px; right: 5px;
+
+                @media only screen and (min-width: 600px) {
+                    right: auto;
+                    width: 400px;
+                }
+            }
         </style>
     </head>
     <body>
         <div id="map"></div>
-        <div id="scroller" style="position:absolute;top:0px;left:0px;z-index:999999;color:white;padding:16px; background-color:#666">
+        <div id="scroller">
             Filter by confidence >= <span id="confidence">0.0</span>
             <input type="range" min="0" max="100" step="1" value="0" onInput="rangeChanged(this.value)"></input>
         </div>
@@ -174,6 +196,29 @@
                     popup.addTo(map);
                 }
             });
+
+            // geocoder
+            document.addEventListener("DOMContentLoaded", (event) => {
+                const el = document.querySelector('ge-autocomplete')
+
+                // 'select' event handler - when a user selects an item from the suggestions
+                el.addEventListener('select', (event) => {
+                    console.log(event.detail, event)
+                    map.jumpTo({
+                        center: event.detail.geometry.coordinates,
+                        zoom: 20
+                    });
+                })
+
+                el.addEventListener('error', (event) => {
+                    console.log(event.detail, event)
+                })
+            })
         </script>
+        <div id="geocoder"><ge-autocomplete
+            api_key="ge-743ca80c06fc413e"
+            placeholder="Search Overture POIs"
+            sources="overture"
+        ></ge-autocomplete></div>
     </body>
 </html>


### PR DESCRIPTION
This PR add a search controller which can be used to query for Overture POIs using the [Geocode Earth beta](https://geocode.earth/blog/2023/overture-maps-pois-beta/) release.

~~I wasn't able to get attribution displaying properly, maybe someone who knows MapLibre better can help there?~~ scratch that, there is an attribution on the search UI
Note: I had to move the 'scroller' to the right (and also down on mobile), not sure how best to handle this?